### PR TITLE
Move fs-extra to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/AlexxNB/rollup-plugin-svg-icons#readme",
   "devDependencies": {
-    "fs-extra": "^8.1.0",
     "open-cli": "^5.0.0",
     "rollup": "^1.27.11",
     "rollup-plugin-terser": "^5.1.3",
     "sirv-cli": "^0.4.5"
   },
   "dependencies": {
+    "fs-extra": "^8.1.0",
     "svgstore": "^3.0.0-2"
   }
 }


### PR DESCRIPTION
Since the package depends on fs-extra at runtime, it should be a regular dependency, rather than a devDependency.