### PR TITLE
fix: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default {
 
 ## Usage in HTML
 
-Use href `bundle.svg#iconid` where `iconid` is base part of svg-icon filename. For ex. if in source folder you have `myicon.svg` then you should use `bandle.svg#myicon`:
+Use href `bundle.svg#iconid` where `iconid` is base part of svg-icon filename. For ex. if in source folder you have `myicon.svg` then you should use `bundle.svg#myicon`:
 
 ```html
 <style>


### PR DESCRIPTION
* In the section **Usage in html** rename `bandle.svg` to `bundle.svg`.